### PR TITLE
Set "Access-Control-Allow-Headers" for /share endpoint.

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ func pHandler(w http.ResponseWriter, req *http.Request) {
 
 func shareHandler(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", allowOrigin)
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type") // Needed for Safari.
 
 	if req.Method != "POST" {
 		http.Error(w, "Forbidden.", http.StatusForbidden)


### PR DESCRIPTION
From empirical testing, this allows the `/share` endpoint to work in Safari on OS X, as well as in Safari and Chrome browsers on iOS.
