### PR TITLE
Improve behavior when unsupported HTTP method used.

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ func pHandler(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", *allowOriginFlag)
 
 	if req.Method != "GET" {
+		w.Header().Set("Allow", "GET")
 		http.Error(w, "Method should be GET.", http.StatusMethodNotAllowed)
 		return
 	}
@@ -67,7 +68,8 @@ func shareHandler(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Access-Control-Allow-Headers", "Content-Type") // Needed for Safari.
 
 	if req.Method != "POST" {
-		http.Error(w, "Forbidden.", http.StatusForbidden)
+		w.Header().Set("Allow", "POST")
+		http.Error(w, "Method should be POST.", http.StatusMethodNotAllowed)
 		return
 	}
 


### PR DESCRIPTION
According to http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.6:

> The response MUST include an Allow header containing a list of valid methods for the requested resource.

Fix that by setting Allow header appropriately when returning Method Not Allowed status code.

Use Method Not Allowed status code for /share endpoint. I don't recall why we went with Forbidden for /share unlike for /p/. Method Not Allowed seems more appropriate and consistent, so use it instead.
