### PR TITLE
Allow IDs of length 11.

### DIFF
--- a/id.go
+++ b/id.go
@@ -9,9 +9,14 @@ import (
 
 // snippetBodyToID mimics the mapping scheme used by the Go Playground.
 func snippetBodyToID(body []byte) string {
-	// This is the actual salt value used by Go Playground, it comes from
-	// https://code.google.com/p/go-playground/source/browse/goplay/share.go#18.
+	// This was the actual salt value used by Go Playground at some time in the past.
+	// It came from https://code.google.com/p/go-playground/source/browse/goplay/share.go#18.
 	// See https://github.com/gopherjs/snippet-store/pull/1#discussion_r22512198 for more details.
+	//
+	// It has since changed. We continue to use the same value for now to keep things consistent.
+	// See https://github.com/golang/playground/blob/a72214bb7a8781349b57129256dc0c64d233ef08/share.go#L17-L19
+	// for the current status. It's possible to change our hashing algorithm to be in sync with
+	// the Go Playground.
 	const salt = "[replace this with something unique]"
 
 	h := sha1.New()
@@ -22,9 +27,10 @@ func snippetBodyToID(body []byte) string {
 }
 
 // validateID returns an error if id is of unexpected format.
+// ID of length 10 and 11 are both supported, so that historical IDs continue to work.
 func validateID(id string) error {
-	if len(id) != 10 {
-		return fmt.Errorf("id length is %v instead of 10", len(id))
+	if len(id) != 10 && len(id) != 11 {
+		return fmt.Errorf("id length is %v instead of 10 or 11", len(id))
 	}
 
 	for _, b := range []byte(id) {

--- a/id_test.go
+++ b/id_test.go
@@ -5,6 +5,7 @@ import "fmt"
 func Example_validateID() {
 	fmt.Println(validateID("D9L6MbPfE4"))
 	fmt.Println(validateID("ABZdez09-_"))
+	fmt.Println(validateID("N_M_YelfGeR"))
 	fmt.Println(validateID("Abc"))
 	fmt.Println(validateID("Abc?q=1235"))
 	fmt.Println(validateID("../../file"))
@@ -13,7 +14,8 @@ func Example_validateID() {
 	// Output:
 	// <nil>
 	// <nil>
-	// id length is 3 instead of 10
+	// <nil>
+	// id length is 3 instead of 10 or 11
 	// id contains unexpected character '?'
 	// id contains unexpected character '.'
 	// id contains unexpected character '\u00e4'


### PR DESCRIPTION
Modern Go Playground IDs have length 11, so we want to treat them as valid.

Update internal comment about `salt` to reflect current state.

Follows golang/playground@cb45f7d93fbf567b8c10011f448aca4d891c8187.